### PR TITLE
remove handling for byteorder custom error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,15 +31,6 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<byteorder::Error> for Error {
-    fn from(err: byteorder::Error) -> Error {
-        match err {
-            byteorder::Error::UnexpectedEOF => Error::UnexpectedEOF,
-            byteorder::Error::Io(io_err) => Error::Io(io_err)
-        }
-    }
-}
-
 impl From<FromUtf8Error> for Error {
     fn from(err: FromUtf8Error) -> Error {
         Error::FormatError(FormatError::Utf8Error(err.utf8_error()))


### PR DESCRIPTION
byteorder::Error has been deprecated, see
https://github.com/BurntSushi/byteorder/commit/e429dfb9ccb74e32c5f1800a20318ea2162ef262
